### PR TITLE
Complete alternative names

### DIFF
--- a/data/import/mapping.yml
+++ b/data/import/mapping.yml
@@ -29,6 +29,9 @@ tables:
     - name: name_zh
       key: name:zh
       type: string
+    - name: all_tags
+      key: null
+      type: hstore_tags
     - key: wikipedia
       name: wikipedia
       type: string
@@ -108,6 +111,9 @@ tables:
     - name: name_zh
       key: name:zh
       type: string
+    - name: all_tags
+      key: null
+      type: hstore_tags
     - key: wikipedia
       name: wikipedia
       type: string
@@ -167,6 +173,9 @@ tables:
     - name: name_zh
       key: name:zh
       type: string
+    - name: all_tags
+      key: null
+      type: hstore_tags  
     - key: wikipedia
       name: wikipedia
       type: string

--- a/data/import/mapping.yml
+++ b/data/import/mapping.yml
@@ -11,26 +11,8 @@ tables:
     - key: name
       name: name
       type: string
-    - name: name_fr
-      key: name:fr
-      type: string
-    - name: name_en
-      key: name:en
-      type: string
-    - name: name_de
-      key: name:de
-      type: string
-    - name: name_es
-      key: name:es
-      type: string
-    - name: name_ru
-      key: name:ru
-      type: string
-    - name: name_zh
-      key: name:zh
-      type: string
-    - name: all_tags
-      key: null
+    - key: null
+      name: all_tags
       type: hstore_tags
     - key: wikipedia
       name: wikipedia
@@ -93,26 +75,8 @@ tables:
     - key: name
       name: name
       type: string
-    - name: name_fr
-      key: name:fr
-      type: string
-    - name: name_en
-      key: name:en
-      type: string
-    - name: name_de
-      key: name:de
-      type: string
-    - name: name_es
-      key: name:es
-      type: string
-    - name: name_ru
-      key: name:ru
-      type: string
-    - name: name_zh
-      key: name:zh
-      type: string
-    - name: all_tags
-      key: null
+    - key: null
+      name: all_tags
       type: hstore_tags
     - key: wikipedia
       name: wikipedia
@@ -155,26 +119,8 @@ tables:
     - key: name
       name: name
       type: string
-    - name: name_fr
-      key: name:fr
-      type: string
-    - name: name_en
-      key: name:en
-      type: string
-    - name: name_de
-      key: name:de
-      type: string
-    - name: name_es
-      key: name:es
-      type: string
-    - name: name_ru
-      key: name:ru
-      type: string
-    - name: name_zh
-      key: name:zh
-      type: string
-    - name: all_tags
-      key: null
+    - key: null
+      name: all_tags
       type: hstore_tags  
     - key: wikipedia
       name: wikipedia

--- a/osmnames/export_osmnames/create_linestrings_view.sql
+++ b/osmnames/export_osmnames/create_linestrings_view.sql
@@ -2,7 +2,7 @@ DROP MATERIALIZED VIEW IF EXISTS mv_linestrings;
 CREATE MATERIALIZED VIEW mv_linestrings AS
 SELECT
   id,
-  languageName AS name,
+  name,
   alternative_names,
   'way'::TEXT as osm_type,
   osm_id::VARCHAR AS osm_id,
@@ -10,13 +10,13 @@ SELECT
   type,
   ST_X(ST_LineInterpolatePoint(ST_Transform(geometry, 4326), 0.5)) AS lon,
   ST_Y(ST_LineInterpolatePoint(ST_Transform(geometry, 4326), 0.5)) AS lat,
-  place_rank AS place_rank,
+  place_rank,
   get_importance(place_rank, wikipedia, country_code) AS importance,
   CASE WHEN class = 'highway' THEN COALESCE(name, '') ELSE '' END AS street,
   COALESCE(parentInfo.city, '') AS city,
   COALESCE(parentInfo.county, '') AS county,
   COALESCE(parentInfo.state, '') AS state,
-  COALESCE(country_name(country_code), '') AS country,
+  COALESCE(get_country_name(country_code), '') AS country,
   COALESCE(country_code, '') AS country_code,
   parentInfo.displayName  AS display_name,
   ST_XMIN(ST_Transform(geometry, 4326)) AS west,
@@ -27,8 +27,6 @@ SELECT
   wikipedia AS wikipedia
 FROM
   osm_linestring,
-  getLanguageName(name, name_fr, name_en, name_de, name_es, name_ru, name_zh) AS languageName,
   determine_class(type) AS class,
-  get_parent_info(languageName, parent_id, place_rank) AS parentInfo,
-  get_alternative_names(all_tags, name, ',') AS alternative_names
+  get_parent_info(osm_linestring.name, parent_id, place_rank) AS parentInfo
 WHERE merged IS NOT TRUE;

--- a/osmnames/export_osmnames/create_linestrings_view.sql
+++ b/osmnames/export_osmnames/create_linestrings_view.sql
@@ -28,7 +28,7 @@ SELECT
 FROM
   osm_linestring,
   getLanguageName(name, name_fr, name_en, name_de, name_es, name_ru, name_zh) AS languageName,
-  getAlternativesNames(name, name_fr, name_en, name_de, name_es, name_ru, name_zh, languageName,',') AS alternative_names,
   determine_class(type) AS class,
-  get_parent_info(languageName, parent_id, place_rank) AS parentInfo
+  get_parent_info(languageName, parent_id, place_rank) AS parentInfo,
+  get_alternative_names(all_tags, name, ',') AS alternative_names
 WHERE merged IS NOT TRUE;

--- a/osmnames/export_osmnames/create_merged_linestrings_view.sql
+++ b/osmnames/export_osmnames/create_merged_linestrings_view.sql
@@ -29,5 +29,5 @@ FROM
   osm_merged_multi_linestring,
   getLanguageName(name, name_fr, name_en, name_de, name_es, name_ru, name_zh) AS languageName,
   get_parent_info(languageName, parent_id, place_rank) AS parentInfo,
-  getAlternativesNames(name, name_fr, name_en, name_de, name_es, name_ru, name_zh, languageName, ',') AS alternative_names
+  get_alternative_names(all_tags, name, ',') AS alternative_names
 ;

--- a/osmnames/export_osmnames/create_merged_linestrings_view.sql
+++ b/osmnames/export_osmnames/create_merged_linestrings_view.sql
@@ -2,23 +2,23 @@ DROP MATERIALIZED VIEW IF EXISTS mv_merged_linestrings;
 CREATE MATERIALIZED VIEW mv_merged_linestrings AS
 SELECT
   id,
-  languageName AS name,
+  name,
   alternative_names,
   'way'::TEXT as osm_type,
   osm_id::VARCHAR AS osm_id,
-  determine_class(type) AS class,
+  class,
   type,
   ST_X(ST_PointOnSurface(ST_Transform(geometry, 4326))) AS lon,
   ST_Y(ST_PointOnSurface(ST_Transform(geometry, 4326))) AS lat,
-  place_rank AS place_rank,
+  place_rank,
   get_importance(place_rank, wikipedia, country_code) AS importance,
-  COALESCE(name, '') AS street,
+  CASE WHEN class = 'highway' THEN COALESCE(name, '') ELSE '' END AS street,
   COALESCE(parentInfo.city, '') AS city,
   COALESCE(parentInfo.county, '') AS county,
   COALESCE(parentInfo.state, '') AS state,
-  COALESCE(country_name(country_code), '') AS country,
+  COALESCE(get_country_name(country_code), '') AS country,
   COALESCE(country_code, '') AS country_code,
-  parentInfo.displayName  AS display_name,
+  parentInfo.displayName AS display_name,
   ST_XMIN(ST_Transform(geometry, 4326)) AS west,
   ST_YMIN(ST_Transform(geometry, 4326)) AS south,
   ST_XMAX(ST_Transform(geometry, 4326)) AS east,
@@ -27,7 +27,5 @@ SELECT
   wikipedia AS wikipedia
 FROM
   osm_merged_multi_linestring,
-  getLanguageName(name, name_fr, name_en, name_de, name_es, name_ru, name_zh) AS languageName,
-  get_parent_info(languageName, parent_id, place_rank) AS parentInfo,
-  get_alternative_names(all_tags, name, ',') AS alternative_names
-;
+  determine_class(type) AS class,
+  get_parent_info(osm_merged_multi_linestring.name, parent_id, place_rank) AS parentInfo;

--- a/osmnames/export_osmnames/create_points_view.sql
+++ b/osmnames/export_osmnames/create_points_view.sql
@@ -29,6 +29,6 @@ FROM
   osm_point,
   getLanguageName(name, name_fr, name_en, name_de, name_es, name_ru, name_zh) AS languageName,
   get_parent_info(languageName, parent_id, place_rank) AS parentInfo,
-  getAlternativesNames(name, name_fr, name_en, name_de, name_es, name_ru, name_zh, languageName, ',') AS alternative_names
+  get_alternative_names(all_tags, name, ',') AS alternative_names
 WHERE
   linked IS FALSE;

--- a/osmnames/export_osmnames/create_points_view.sql
+++ b/osmnames/export_osmnames/create_points_view.sql
@@ -2,7 +2,7 @@ DROP MATERIALIZED VIEW IF EXISTS mv_points;
 CREATE MATERIALIZED VIEW mv_points AS
 SELECT
   id,
-  languageName AS name,
+  name,
   alternative_names,
   'node'::TEXT as osm_type,
   osm_id::VARCHAR AS osm_id,
@@ -10,15 +10,15 @@ SELECT
   type,
   ST_X(ST_Transform(geometry, 4326)) AS lon,
   ST_Y(ST_Transform(geometry, 4326)) AS lat,
-  place_rank AS place_rank,
+  place_rank,
   get_importance(place_rank, wikipedia, country_code) AS importance,
   ''::TEXT AS street,
   COALESCE(parentInfo.city, '') AS city,
   COALESCE(parentInfo.county, '') AS county,
   COALESCE(parentInfo.state, '') AS state,
-  COALESCE(country_name(country_code), '') AS country,
+  COALESCE(get_country_name(country_code), '') AS country,
   COALESCE(country_code, '') AS country_code,
-  parentInfo.displayName  AS display_name,
+  parentInfo.displayName AS display_name,
   ST_XMIN(ST_Transform(geometry, 4326)) AS west,
   ST_YMIN(ST_Transform(geometry, 4326)) AS south,
   ST_XMAX(ST_Transform(geometry, 4326)) AS east,
@@ -27,8 +27,6 @@ SELECT
   wikipedia
 FROM
   osm_point,
-  getLanguageName(name, name_fr, name_en, name_de, name_es, name_ru, name_zh) AS languageName,
-  get_parent_info(languageName, parent_id, place_rank) AS parentInfo,
-  get_alternative_names(all_tags, name, ',') AS alternative_names
+  get_parent_info(osm_point.name, parent_id, place_rank) AS parentInfo
 WHERE
   linked IS FALSE;

--- a/osmnames/export_osmnames/create_polygons_view.sql
+++ b/osmnames/export_osmnames/create_polygons_view.sql
@@ -31,5 +31,5 @@ FROM
   get_parent_info(languageName, parent_id, place_rank) AS parentInfo,
   getTypeForRelations(linked_osm_id, type, place_rank) AS relation_type,
   COALESCE(NULLIF(getNameForRelations(linked_osm_id, relation_type), ''), languageName) AS relationName,
-  getAlternativesNames(name, name_fr, name_en, name_de, name_es, name_ru, name_zh, relationName, ',') AS alternative_names
+  get_alternative_names(all_tags, name, ',') AS alternative_names
 ;

--- a/osmnames/export_osmnames/create_polygons_view.sql
+++ b/osmnames/export_osmnames/create_polygons_view.sql
@@ -2,7 +2,7 @@ DROP MATERIALIZED VIEW IF EXISTS mv_polygons;
 CREATE MATERIALIZED VIEW mv_polygons AS
 SELECT
   id,
-  relationName AS name,
+  relation_name AS name,
   alternative_names,
   CASE WHEN osm_id > 0 THEN 'way' ELSE 'relation' END AS osm_type,
   abs(osm_id)::VARCHAR as osm_id,
@@ -10,13 +10,13 @@ SELECT
   relation_type,
   ST_X(ST_PointOnSurface(ST_Buffer(ST_Transform(geometry, 4326), 0.0))) AS lon,
   ST_Y(ST_PointOnSurface(ST_Buffer(ST_Transform(geometry, 4326), 0.0))) AS lat,
-  place_rank AS place_rank,
+  place_rank,
   get_importance(place_rank, wikipedia, country_code) AS importance,
   ''::TEXT AS street,
   COALESCE(parentInfo.city, '') AS city,
   COALESCE(parentInfo.county, '') AS county,
   COALESCE(parentInfo.state, '') AS state,
-  COALESCE(country_name(country_code), '') AS country,
+  COALESCE(get_country_name(country_code), '') AS country,
   COALESCE(country_code, '') AS country_code,
   parentInfo.displayName  AS display_name,
   ST_XMIN(ST_Transform(geometry, 4326)) AS west,
@@ -27,9 +27,6 @@ SELECT
   wikipedia AS wikipedia
 FROM
   osm_polygon,
-  getLanguageName(name, name_fr, name_en, name_de, name_es, name_ru, name_zh) AS languageName,
-  get_parent_info(languageName, parent_id, place_rank) AS parentInfo,
-  getTypeForRelations(linked_osm_id, type, place_rank) AS relation_type,
-  COALESCE(NULLIF(getNameForRelations(linked_osm_id, relation_type), ''), languageName) AS relationName,
-  get_alternative_names(all_tags, name, ',') AS alternative_names
-;
+  get_parent_info(osm_polygon.name, parent_id, place_rank) AS parentInfo,
+  get_type_for_relations(linked_osm_id, type, place_rank) AS relation_type,
+  COALESCE(NULLIF(get_name_for_relations(linked_osm_id, relation_type), ''), osm_polygon.name) AS relation_name;

--- a/osmnames/import_osm/create_custom_columns.sql
+++ b/osmnames/import_osm/create_custom_columns.sql
@@ -1,16 +1,19 @@
 ALTER TABLE osm_linestring ADD COLUMN parent_id BIGINT;
 ALTER TABLE osm_linestring ADD COLUMN place_rank INTEGER;
 ALTER TABLE osm_linestring ADD COLUMN country_code VARCHAR(2);
+ALTER TABLE osm_linestring ADD COLUMN alternative_names TEXT;
 ALTER TABLE osm_linestring ADD COLUMN merged BOOL;
 
 ALTER TABLE osm_polygon ADD COLUMN parent_id BIGINT;
 ALTER TABLE osm_polygon ADD COLUMN place_rank INTEGER;
 ALTER TABLE osm_polygon ADD COLUMN linked_osm_id BIGINT;
+ALTER TABLE osm_polygon ADD COLUMN alternative_names TEXT;
 ALTER TABLE osm_polygon ADD COLUMN country_code VARCHAR(2);
 
 ALTER TABLE osm_point ADD COLUMN parent_id BIGINT;
 ALTER TABLE osm_point ADD COLUMN place_rank INTEGER;
 ALTER TABLE osm_point ADD COLUMN country_code VARCHAR(2);
+ALTER TABLE osm_point ADD COLUMN alternative_names TEXT;
 ALTER TABLE osm_point ADD COLUMN linked BOOL;
 
 ALTER TABLE osm_housenumber ADD COLUMN parent_id BIGINT;

--- a/osmnames/import_osm/delete_unusable_entries.sql
+++ b/osmnames/import_osm/delete_unusable_entries.sql
@@ -1,33 +1,13 @@
--- cleanup unusable entries
 -- remove all rows where all names are empty or null values
-DELETE FROM osm_polygon WHERE (name = '' AND name_fr = '' AND name_en = '' AND name_de = '' AND name_es = '' AND name_ru = '' AND name_zh = '') IS NOT FALSE;
-DELETE FROM osm_point WHERE (name = '' AND name_fr = '' AND name_en = '' AND name_de = '' AND name_es = '' AND name_ru = '' AND name_zh = '') IS NOT FALSE;
-DELETE FROM osm_linestring WHERE (name = '' AND name_fr = '' AND name_en = '' AND name_de = '' AND name_es = '' AND name_ru = '' AND name_zh = '') IS NOT FALSE;
+DELETE FROM osm_polygon WHERE name = '' IS NOT FALSE;
+DELETE FROM osm_point WHERE name = '' IS NOT FALSE;
+DELETE FROM osm_linestring WHERE name = '' IS NOT FALSE;
 
 -- remove tabs, so the export in tsv is valid
 UPDATE osm_polygon SET name =  regexp_replace(name,'\t', ' ') WHERE name LIKE '%'||chr(9)||'%';
-UPDATE osm_polygon SET name_fr =  regexp_replace(name_fr,'\t', ' ') WHERE name_fr LIKE '%'||chr(9)||'%';
-UPDATE osm_polygon SET name_en =  regexp_replace(name_en,'\t', ' ') WHERE name_en LIKE '%'||chr(9)||'%';
-UPDATE osm_polygon SET name_de =  regexp_replace(name_de,'\t', ' ') WHERE name_de LIKE '%'||chr(9)||'%';
-UPDATE osm_polygon SET name_es =  regexp_replace(name_es,'\t', ' ') WHERE name_es LIKE '%'||chr(9)||'%';
-UPDATE osm_polygon SET name_ru =  regexp_replace(name_ru,'\t', ' ') WHERE name_ru LIKE '%'||chr(9)||'%';
-UPDATE osm_polygon SET name_zh =  regexp_replace(name_zh,'\t', ' ') WHERE name_zh LIKE '%'||chr(9)||'%';
-
 UPDATE osm_point SET name =  regexp_replace(name,'\t', ' ') WHERE name LIKE '%'||chr(9)||'%';
-UPDATE osm_point SET name_fr =  regexp_replace(name_fr,'\t', ' ') WHERE name_fr LIKE '%'||chr(9)||'%';
-UPDATE osm_point SET name_en =  regexp_replace(name_en,'\t', ' ') WHERE name_en LIKE '%'||chr(9)||'%';
-UPDATE osm_point SET name_de =  regexp_replace(name_de,'\t', ' ') WHERE name_de LIKE '%'||chr(9)||'%';
-UPDATE osm_point SET name_es =  regexp_replace(name_es,'\t', ' ') WHERE name_es LIKE '%'||chr(9)||'%';
-UPDATE osm_point SET name_ru =  regexp_replace(name_ru,'\t', ' ') WHERE name_ru LIKE '%'||chr(9)||'%';
-UPDATE osm_point SET name_zh =  regexp_replace(name_zh,'\t', ' ') WHERE name_zh LIKE '%'||chr(9)||'%';
-
 UPDATE osm_linestring SET name =  regexp_replace(name,'\t', ' ') WHERE name LIKE '%'||chr(9)||'%';
-UPDATE osm_linestring SET name_fr =  regexp_replace(name_fr,'\t', ' ') WHERE name_fr LIKE '%'||chr(9)||'%';
-UPDATE osm_linestring SET name_en =  regexp_replace(name_en,'\t', ' ') WHERE name_en LIKE '%'||chr(9)||'%';
-UPDATE osm_linestring SET name_de =  regexp_replace(name_de,'\t', ' ') WHERE name_de LIKE '%'||chr(9)||'%';
-UPDATE osm_linestring SET name_es =  regexp_replace(name_es,'\t', ' ') WHERE name_es LIKE '%'||chr(9)||'%';
-UPDATE osm_linestring SET name_ru =  regexp_replace(name_ru,'\t', ' ') WHERE name_ru LIKE '%'||chr(9)||'%';
-UPDATE osm_linestring SET name_zh =  regexp_replace(name_zh,'\t', ' ') WHERE name_zh LIKE '%'||chr(9)||'%';
+
 
 --delete entries with faulty geometries from import
 DELETE FROM osm_polygon WHERE ST_IsEmpty(geometry);

--- a/osmnames/import_osm/import_osm.py
+++ b/osmnames/import_osm/import_osm.py
@@ -12,6 +12,7 @@ def import_osm():
     sanatize_for_import()
     import_pbf_file()
     create_custom_columns()
+    set_names()
     create_osm_elements_view() 
     create_helper_tables()
     prepare_imported_data()
@@ -55,6 +56,10 @@ def import_pbf_file():
 
 def create_custom_columns():
     exec_sql_from_file("create_custom_columns.sql", cwd=os.path.dirname(__file__))
+
+
+def set_names():
+    exec_sql_from_file("set_names.sql", cwd=os.path.dirname(__file__))
 
 
 def create_osm_elements_view():

--- a/osmnames/import_osm/merge_corresponding_streets.sql
+++ b/osmnames/import_osm/merge_corresponding_streets.sql
@@ -7,13 +7,7 @@ CREATE TABLE osm_merged_multi_linestring AS
     min(a.osm_id) AS osm_id,
     string_agg(DISTINCT a.type,',') AS type,
     a.name,
-    a.all_tags,
-    max(a.name_fr) AS name_fr,
-    max(a.name_en) AS name_en,
-    max(a.name_de) AS name_de,
-    max(a.name_es) AS name_es,
-    max(a.name_ru) AS name_ru,
-    max(a.name_zh) AS name_zh,
+    max(a.alternative_names) AS alternative_names,
     max(a.wikipedia) AS wikipedia,
     max(a.wikidata) AS wikidata,
     ST_UNION(array_agg(a.geometry)) AS geometry,
@@ -31,8 +25,7 @@ CREATE TABLE osm_merged_multi_linestring AS
     a.id!=b.id
   GROUP BY
     a.parent_id,
-    a.name,
-    a.all_tags;
+    a.name;
 
 ALTER TABLE osm_merged_multi_linestring ADD PRIMARY KEY (id);
 

--- a/osmnames/import_osm/merge_corresponding_streets.sql
+++ b/osmnames/import_osm/merge_corresponding_streets.sql
@@ -7,6 +7,7 @@ CREATE TABLE osm_merged_multi_linestring AS
     min(a.osm_id) AS osm_id,
     string_agg(DISTINCT a.type,',') AS type,
     a.name,
+    a.all_tags,
     max(a.name_fr) AS name_fr,
     max(a.name_en) AS name_en,
     max(a.name_de) AS name_de,
@@ -30,7 +31,8 @@ CREATE TABLE osm_merged_multi_linestring AS
     a.id!=b.id
   GROUP BY
     a.parent_id,
-    a.name;
+    a.name,
+    a.all_tags;
 
 ALTER TABLE osm_merged_multi_linestring ADD PRIMARY KEY (id);
 

--- a/osmnames/import_osm/set_names.sql
+++ b/osmnames/import_osm/set_names.sql
@@ -1,0 +1,51 @@
+-- Order of priority for 'name' is: default name, en, fr, de, es, ru, zh
+DROP FUNCTION IF EXISTS get_name(HSTORE);
+CREATE FUNCTION get_name(all_tags HSTORE) RETURNS TEXT AS $$
+  SELECT COALESCE(all_tags -> 'name:en',
+                  all_tags -> 'name:fr',
+                  all_tags -> 'name:de',
+                  all_tags -> 'name:es',
+                  all_tags -> 'name:ru',
+                  all_tags -> 'name:zh');
+$$ LANGUAGE 'sql' IMMUTABLE;
+
+
+
+CREATE OR REPLACE FUNCTION array_distinct(anyarray)
+RETURNS anyarray AS $$
+  SELECT ARRAY(SELECT DISTINCT unnest($1))
+$$ LANGUAGE sql;
+
+
+/*  Get values for all the name tags as defined in http://wiki.openstreetmap.org/wiki/Key:name
+    The alternative_names string will contain all distinct names except the one already set as 'name' */
+DROP FUNCTION IF EXISTS get_alternative_names(HSTORE, TEXT, VARCHAR);
+CREATE FUNCTION get_alternative_names(all_tags HSTORE, name TEXT, delimiter character varying)
+RETURNS TEXT AS $$
+DECLARE
+  alternative_names TEXT[];
+  key TEXT;
+BEGIN
+  FOREACH key in ARRAY akeys(all_tags)
+  LOOP
+    IF (key LIKE 'name:%' OR key LIKE '%[_]name') AND (all_tags->key NOT ILIKE name)
+    THEN
+      alternative_names := array_append(alternative_names, all_tags->key);
+    END IF;
+  END LOOP;
+  alternative_names := array_distinct(alternative_names);
+RETURN array_to_string(alternative_names, delimiter);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+
+-- If the 'name' is empty or null, get name in another available language
+UPDATE osm_linestring SET name = get_name(all_tags) WHERE name = '' IS NOT FALSE;
+UPDATE osm_polygon SET name = get_name(all_tags) WHERE name = '' IS NOT FALSE;
+UPDATE osm_point SET name = get_name(all_tags) WHERE name = '' IS NOT FALSE;
+
+
+-- Get all alternative names, concatenated as a string, separated by commas
+UPDATE osm_linestring SET alternative_names = get_alternative_names(all_tags, name, ',');
+UPDATE osm_polygon SET alternative_names = get_alternative_names(all_tags, name, ',');
+UPDATE osm_point SET alternative_names = get_alternative_names(all_tags, name, ',');


### PR DESCRIPTION
Export all alternative names of a place, separated by commas, in the field alternative_names. This includes the name in different languages and all the 'name' tags defined in [OpenStreetMap](http://wiki.openstreetmap.org/wiki/Key:name).